### PR TITLE
Adjust ESLint rules

### DIFF
--- a/app/services/league/.eslintrc.json
+++ b/app/services/league/.eslintrc.json
@@ -14,6 +14,7 @@
     "indent": ["error", 4],
     "no-underscore-dangle": "warn",
     "consistent-return": "warn",
-    "no-shadow": "warn"
+    "no-shadow": "warn",
+    "linebreak-style": "off"
     }
 }

--- a/app/services/stock/.eslintrc.json
+++ b/app/services/stock/.eslintrc.json
@@ -14,6 +14,7 @@
         "indent": ["error", 4],
         "no-underscore-dangle": "warn",
         "consistent-return": "warn",
-        "no-shadow": "warn"
+        "no-shadow": "warn",
+        "linebreak-style": "off"
     }
 }

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -24,7 +24,8 @@
         "react/jsx-indent": ["error", 4],
 	    "react/jsx-indent-props": ["error", 4],
         "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-        "react/prop-types": ["off"]
-
+        "react/prop-types": ["off"],
+        "linebreak-style": "off",
+        "consistent-return": "warn"
     }
 }


### PR DESCRIPTION
- Add `"linebreak-style": "off"` to all linter configurations to stop issues with VSCode in Windows.
- Warn consistent return on frontend