### PR TITLE
Portfolio retrieval endpoint and fix trading

### DIFF
--- a/app/services/league/controllers/leagueController.js
+++ b/app/services/league/controllers/leagueController.js
@@ -111,7 +111,7 @@ const calculateCostBasis = (ticker, portfolio) => {
             numShares += order.quantity;
         }
     });
-    if (numShares <= 0) return 0; //Should not happen
+    if (numShares <= 0) return 0; // Should not happen
     return totalCost / numShares;
 };
 
@@ -272,7 +272,7 @@ exports.getPortfolio = async (req, res) => {
         const currentPrices = [];
         const statistics = [];
         for (let i = 0; i < portfolioInfo.holdings.length; i += 1) {
-            const { ticker, quantity } = portfolioInfo.holdings[i];
+            const { ticker } = portfolioInfo.holdings[i];
             // Start async calls for current price and statistics
             currentPrices.push(getMarketPrice(ticker));
             statistics.push(getStatistics(ticker));
@@ -296,7 +296,7 @@ exports.getPortfolio = async (req, res) => {
         const setNames = await Promise.all(statistics).then((result) => {
             // Get equity name
             for (let i = 0; i < portfolioInfo.holdings.length; i += 1) {
-                const { ticker, quantity } = portfolioInfo.holdings[i];
+                const { ticker } = portfolioInfo.holdings[i];
                 remapHoldings[ticker].equityName = result[i].equityName;
             }
         });

--- a/app/services/league/controllers/leagueController.js
+++ b/app/services/league/controllers/leagueController.js
@@ -172,3 +172,15 @@ exports.disbandLeague = async (req, res) => {
     delReq.then(() => res.send(`Successfully disbanded league! (${res.locals.league.leagueName})`))
         .catch((err) => res.status(422).send(`Cannot disband league cleanly. Unknown Error occurred. \n ${err}`));
 };
+
+exports.getPortfolio = (req, res) => {
+    const { username, league } = res.locals;
+    let userPortfolio;
+    league.portfolioList.forEach((portfolio) => {
+        if (portfolio.owner === username) {
+            userPortfolio = portfolio;
+        }
+    });
+    if (!userPortfolio) res.status(404).send('User portfolio not found');
+    res.send(userPortfolio);
+};

--- a/app/services/league/middleware/validate.js
+++ b/app/services/league/middleware/validate.js
@@ -48,7 +48,7 @@ exports.signup = [
     },
 ];
 
-exports.ticker = [
+exports.validTicker = [
     check('tickerSymbol')
         .trim()
         .toLowerCase()

--- a/app/services/league/models/portfolioModel.js
+++ b/app/services/league/models/portfolioModel.js
@@ -57,10 +57,14 @@ const portfolioSchema = new mongoose.Schema({
         type: Number,
         required: true,
     },
-    netWorth: {
+    currentNetWorth: {
         type: Number,
         required: true,
     },
+    netWorth: [{
+        date: Date,
+        worth: Number,
+    }],
     currentHoldings: [{
         ticker: String,
         quantity: Number,

--- a/app/services/league/routes/leagueRoutes.js
+++ b/app/services/league/routes/leagueRoutes.js
@@ -20,4 +20,6 @@ router.get('/find/names', leagueController.getLeagueNames);
 
 router.get('/find/:leagueName', leagueController.getLeagueByName);
 
+router.get('/portfolio', leagueValidation.authValidation, leagueValidation.findValidLeague, leagueController.getPortfolio);
+
 module.exports = router;

--- a/app/services/league/routes/tradeRoutes.js
+++ b/app/services/league/routes/tradeRoutes.js
@@ -5,6 +5,6 @@ const router = express.Router();
 const tradeController = require('../controllers/tradeController');
 const tradeValidation = require('../middleware/validate');
 
-router.post('/submit', tradeValidation.authValidation, tradeValidation.findValidLeague, tradeValidation.ticker, tradeController.trade);
+router.post('/submit', tradeValidation.authValidation, tradeValidation.findValidLeague, tradeValidation.validTicker, tradeController.trade);
 
 module.exports = router;

--- a/app/services/league/utils/stockUtils.js
+++ b/app/services/league/utils/stockUtils.js
@@ -9,3 +9,13 @@ exports.getMarketPrice = async (ticker) => {
         console.error(err);
     }
 };
+
+exports.getStatistics = async (ticker) => {
+    try {
+        const statistics = await fetch(`${process.env.STOCK_URL}/equity/statistics/${ticker}`)
+            .then((response) => response.json());
+        return statistics;
+    } catch (err) {
+        console.error(err);
+    }
+};

--- a/app/services/league/utils/stockUtils.js
+++ b/app/services/league/utils/stockUtils.js
@@ -1,0 +1,11 @@
+const fetch = require('node-fetch');
+
+exports.getMarketPrice = async (ticker) => {
+    try {
+        const currPrice = await fetch(`${process.env.STOCK_URL}/equity/current/${ticker}`)
+            .then((response) => response.json());
+        return currPrice;
+    } catch (err) {
+        console.error(err);
+    }
+};


### PR DESCRIPTION
# Spaghetti warning - I was very tired :(

Addresses #34

Following the structure outlined by Christine and Yati for the portfolio endpoint in the `viewPortfolio` branch but using the new schema.

`/league/portfolio`
Currently just used for the user's portfolio, will provide another endpoint to access other users' portfolios later. As a result, the body of the request is just the league:

```
{
  leagueName: <league name>
}
```

![image](https://user-images.githubusercontent.com/31025257/112422460-55e09080-8d07-11eb-930b-52857ae13155.png)

Unfortunately, the holdings are now stored as an object of objects rather than an array of objects because mutability and object references were making me go crazy.

This should handle all of the data required on the portfolio page. For net worth, we will need to find some way of regularly calculating it; this will probably handled along with limit orders later.

I also fixed some issues with trading - previously the user's holdings would be overwritten on occasion.



