### PR TITLE
Added indicator for already joined leagues

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "node-sass": "^5.0.0",
         "react": "^17.0.1",
         "react-bootstrap": "^1.5.0",
+        "react-bootstrap-icons": "^1.4.0",
         "react-chartjs-2": "^2.11.1",
         "react-dom": "^17.0.1",
         "react-router": "^5.2.0",
@@ -17060,6 +17061,17 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-bootstrap-icons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-icons/-/react-bootstrap-icons-1.4.0.tgz",
+      "integrity": "sha512-rxT8IxIU3Cnnj4y+rDJvlj5qITNfQP0jdw0e1gGCuyNDQDxvRvrA6QEFSLmWBgMqC/hig3CnZ+Snx2GwXbPxmQ==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6 || ^17"
       }
     },
     "node_modules/react-chartjs-2": {
@@ -34599,6 +34611,14 @@
         "react-transition-group": "^4.4.1",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"
+      }
+    },
+    "react-bootstrap-icons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-icons/-/react-bootstrap-icons-1.4.0.tgz",
+      "integrity": "sha512-rxT8IxIU3Cnnj4y+rDJvlj5qITNfQP0jdw0e1gGCuyNDQDxvRvrA6QEFSLmWBgMqC/hig3CnZ+Snx2GwXbPxmQ==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "react-chartjs-2": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "node-sass": "^5.0.0",
     "react": "^17.0.1",
     "react-bootstrap": "^1.5.0",
+    "react-bootstrap-icons": "^1.4.0",
     "react-chartjs-2": "^2.11.1",
     "react-dom": "^17.0.1",
     "react-router": "^5.2.0",

--- a/frontend/src/components/JoinLeague/JoinLeague.js
+++ b/frontend/src/components/JoinLeague/JoinLeague.js
@@ -113,43 +113,55 @@ function JoinLeague() {
                             </tr>
                         </thead>
                         <tbody>
-                            {leagues && leagues.map((league) => (
-                                <tr>
-                                    <td>{(() => {
-                                        if (league.playerList.includes(username)) {
+                            {leagues && leagues.map((league) => {
+                                const alreadyJoined = league.playerList.includes(username);
+                                return (
+                                    <tr>
+                                        <td>{(() => {
+                                            if (alreadyJoined) {
+                                                return (
+                                                    <div>
+                                                        {league.leagueName}
+                                                        <OverlayTrigger overlay={<Tooltip>You are already in this league.</Tooltip>}>
+                                                            <Check />
+                                                        </OverlayTrigger>
+                                                    </div>
+                                                );
+                                            }
+                                            console.log('success');
+                                            return league.leagueName;
+                                        }
+                                        )()}
+                                        </td>
+                                        <td>
+                                            {`${new Date(league.settings.endDate).getMonth() + 1
+                                            }/${new Date(league.settings.endDate).getDate() + 1}/${new Date(league.settings.endDate).getFullYear()}`}
+                                        </td>
+                                        <td>
+                                            {league.playerList.length}
+                                            /
+                                            {league.settings.maxPlayers}
+                                        </td>
+                                        {league.settings.public
+                                            ? <td>Public</td>
+                                            : <td>Private</td>}
+                                        <td>{(() => {
+                                            if (alreadyJoined) {
+                                                return (
+                                                    <Button style={{ backgroundColor: 'gray', borderColor: 'gray' }}>Joined</Button>
+                                                );
+                                            }
                                             return (
-                                                <div>
-                                                    {league.leagueName}
-                                                    <OverlayTrigger overlay={<Tooltip>You are already in this league.</Tooltip>}>
-                                                        <Check />
-                                                    </OverlayTrigger>
-                                                </div>
+                                                <Button onClick={() => handleJoin(league)}>
+                                                    Join League
+                                                </Button>
                                             );
                                         }
-                                        console.log('success');
-                                        return league.leagueName;
-                                    }
-                                    )()}
-                                    </td>
-                                    <td>
-                                        {`${new Date(league.settings.endDate).getMonth() + 1
-                                        }/${new Date(league.settings.endDate).getDate() + 1}/${new Date(league.settings.endDate).getFullYear()}`}
-                                    </td>
-                                    <td>
-                                        {league.playerList.length}
-                                        /
-                                        {league.settings.maxPlayers}
-                                    </td>
-                                    {league.settings.public
-                                        ? <td>Public</td>
-                                        : <td>Private</td>}
-                                    <td>
-                                        <Button onClick={() => handleJoin(league)}>
-                                            Join League
-                                        </Button>
-                                    </td>
-                                </tr>
-                            ))}
+                                        )()}
+                                        </td>
+                                    </tr>
+                                );
+                            })}
                         </tbody>
                     </Table>
                 </Form>

--- a/frontend/src/components/JoinLeague/JoinLeague.js
+++ b/frontend/src/components/JoinLeague/JoinLeague.js
@@ -5,9 +5,15 @@ import Form from 'react-bootstrap/Form';
 import Alert from 'react-bootstrap/Alert';
 import Container from 'react-bootstrap/Container';
 import Modal from 'react-bootstrap/Modal';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+import { Check } from 'react-bootstrap-icons';
 import '../../styles/JoinLeague/JoinLeague.scss';
 
 function JoinLeague() {
+    /* eslint-disable max-len */
+    const username = sessionStorage.getItem('username');
+
     const [leagues, setLeagues] = useState([]);
     const [selectedLeague, setSelectedLeague] = useState('');
     const [showModal, setShowModal] = useState(false);
@@ -109,7 +115,22 @@ function JoinLeague() {
                         <tbody>
                             {leagues && leagues.map((league) => (
                                 <tr>
-                                    <td>{league.leagueName}</td>
+                                    <td>{(() => {
+                                        if (league.playerList.includes(username)) {
+                                            return (
+                                                <div>
+                                                    {league.leagueName}
+                                                    <OverlayTrigger overlay={<Tooltip>You are already in this league.</Tooltip>}>
+                                                        <Check />
+                                                    </OverlayTrigger>
+                                                </div>
+                                            );
+                                        }
+                                        console.log('success');
+                                        return league.leagueName;
+                                    }
+                                    )()}
+                                    </td>
                                     <td>
                                         {`${new Date(league.settings.endDate).getMonth() + 1
                                         }/${new Date(league.settings.endDate).getDate() + 1}/${new Date(league.settings.endDate).getFullYear()}`}


### PR DESCRIPTION
Added an indicator on the Join League page for already joined leagues that is separate from the backend validation when user attempts to join a league they are already a member of. Also added a relevant tooltip to make it more clear to the user. I added the `react-bootstrap-icons` package for the indicator and hopefully we can use other icons throughout the website as well. 

Screenshots:

Checkmark indicator:
![image](https://user-images.githubusercontent.com/29742300/114434074-986fed00-9b90-11eb-9935-56e0d537942d.png)

Tooltip:
![image](https://user-images.githubusercontent.com/29742300/114434112-a0c82800-9b90-11eb-8dc2-186426157527.png)

