### PR TITLE
Summary endpoint and insert net worth

### DIFF
--- a/app/services/league/controllers/leagueController.js
+++ b/app/services/league/controllers/leagueController.js
@@ -484,9 +484,10 @@ exports.getPortfolioNews = async (req, res) => {
 };
 
 const getLastFriday = (day) => {
-    const t = day.getDate() + (6 - day.getDay() - 1) - 7;
-    let lastFriday = new Date();
-    lastFriday.setDate(t);
+    let lastFriday = new Date(day);
+    while (lastFriday.getDay() !=5 ) {
+        lastFriday.setDate(lastFriday.getDate() - 1);
+    }
     return lastFriday;
 };
 
@@ -516,19 +517,24 @@ exports.getSummary = async (req, res) => {
     let leagueReturn;
     let startWeek = new Date(req.query.week);
     const lastFriday = getLastFriday(startWeek);
+    let tempDate = new Date(lastFriday);
     let endDay = new Date();
     const pastMonday = getMonday(endDay);
     startWeek.setHours(0,0,0,0);
     lastFriday.setHours(0,0,0,0);
-    endDay.setHours(0,0,0,0);
     pastMonday.setHours(0,0,0,0);
     if (startWeek < pastMonday) {
-        endDay.setDate(lastFriday.getDate() + 7);
+        tempDate.setDate(tempDate.getDate() + 7);
+        endDay = new Date(tempDate);
+        console.log(`tempDate: ${tempDate}`);
+        console.log(`endDay: ${endDay}`);
     } else {
         if (new Date().getHours() < 16) {
             endDay.setDate(endDay.getDate() - 1);
         }
     }
+
+    endDay.setHours(0,0,0,0);
 
     const leagueInfo = await League.findOne({ leagueName: req.params.leagueName }, (err, result) => {
         if (err) throw err;
@@ -540,8 +546,7 @@ exports.getSummary = async (req, res) => {
         portfolio.netWorth.forEach((day) => {
             date = new Date(day.date);
             date.setHours(0,0,0,0);
-            if (date.getTime() === lastFriday.getTime()) {
-                
+            if (date.getTime() === lastFriday.getTime()) {        
                 if (portfolio.owner === username) startWorth = day.worth;
                 else startPortfolioTotals += day.worth;
             }

--- a/app/services/league/routes/leagueRoutes.js
+++ b/app/services/league/routes/leagueRoutes.js
@@ -55,7 +55,7 @@ router.get('/find/names', leagueController.getLeagueNames);
  * @function
  * @name get/find/:leagueName
  */
-// router.get('/find/:leagueName', leagueController.getLeagueByName);
+router.get('/find/:leagueName', leagueController.getLeagueByName);
 
 /**
  * Route handling query of user's portfolio in specified league
@@ -65,5 +65,9 @@ router.get('/find/names', leagueController.getLeagueNames);
 router.get('/portfolio/:league', leagueValidation.authValidation, leagueController.getPortfolio);
 
 router.get('/news/:league', leagueValidation.authValidation, leagueController.getPortfolioNews);
+
+router.get('/summary/:leagueName', leagueValidation.authValidation, leagueController.getSummary);
+
+router.post('/insert/:leagueName', leagueValidation.authValidation, leagueController.insertNetWorth);
 
 module.exports = router;


### PR DESCRIPTION
I just finished the summary endpoint and the implementation is a bit wonky so I will try to explain what's going on. Since the summaries are being calculated "weekwise", first the portfolio value from previous Friday's close is pulled, since that is what is being saved to our database. This portfolio value is then compared to either the following Friday if this is a past week or whatever portfolio value was at the most recent close if this is a current week(like if you're checking the summary page in the middle of the week).

Updated response body:
```
{
    "startAverage": "521.17",
    "endAverage": "420.33",
    "leaguePercentageReturn": "-23.99",
    "leagueDollarReturn": "-100.84",
    "personalStartWorth": "417.17",
    "personalEndWorth": "406.33",
    "personalPercentageReturn": "-2.67",
    "personalDollarReturn": "-10.84",
    "dollarReturnRankings": [
        {
            "username": "jscheire4",
            "dollarReturn": "-10.84"
        },
        {
            "username": "jscheire5",
            "dollarReturn": "-100.84"
        }
    ],
    "percentageReturnRankings": [
        {
            "username": "jscheire4",
            "percentageReturn": "-2.67"
        },
        {
            "username": "jscheire5",
            "percentageReturn": "-23.99"
        }
    ],
    "dollarReturnPlace": 1,
    "percentageReturnPlace": 1,
    "SPPercentageReturn": "1.40",
    "SPReturnDifference": "-4.07"
}
```
`startAverage`: average of all portfolio values in the league(other than your own) based on the previous Friday's close
`endAverage`: average of all portfolio values in the league(other than your own)  based on the following Friday's close or the last close(depending on past or present)
`leaguePercentageReturn`: average return of all portfolios(other than your own)
`leagueDollarReturn`: dollar value of the previous field
`personalStartWorth`: your portfolio value based on previous Friday's close
`personalEndWorth`: your portfolio value based on following Friday's close or the last close(depending on past or present)
`personalPercentageReturn`: same as leaguePercentageReturn except for your portfolio 
`personalDollarReturn`: same as leagueDollarReturn except for your portfolio 
`dollarReturnRankings`: array of JSON objects that ranks dollar return for each player in descending order
`percentageReturnRankings`: array of JSON objects that ranks percentage return for each player in descending order
`dollarReturnPlace`: your place in the dollar return rankings
`percentageReturnPlace`: your place in the percentage return rankings
`SPPercentageReturn`: the return for the S&P 500 in the given week
`SPReturnDifference`: your performance compared to the S&P 500; the difference between your return and the S&P 500

I expect to determine which metrics, like above/below average relative to the rest of the league, on the frontend. Let me know if you think if there's more information that you think would be useful to add.