### PR TITLE
Filtering & Organizing Join League Columns

### DIFF
--- a/frontend/src/components/CreateLeague/CreateLeague.js
+++ b/frontend/src/components/CreateLeague/CreateLeague.js
@@ -253,13 +253,12 @@ function CreateLeague() {
                                         <Form.Control
                                             type="number"
                                             min="1"
-                                            max="12"
                                             placeholder="Enter max players"
                                             required
                                             onChange={(e) => setMaxPlayers(e.target.value)}
                                         />
                                         <Form.Control.Feedback type="invalid">
-                                            Please provide a number between 1 and 12
+                                            Please provide a number greater than 0
                                         </Form.Control.Feedback>
                                     </InputGroup>
                                 </Col>

--- a/frontend/src/components/JoinLeague/JoinLeague.js
+++ b/frontend/src/components/JoinLeague/JoinLeague.js
@@ -14,7 +14,7 @@ import '../../styles/JoinLeague/JoinLeague.scss';
 function JoinLeague() {
     /* eslint-disable max-len */
     const username = sessionStorage.getItem('username');
-
+    const [allLeagues, setAllLeagues] = useState([]);
     const [leagues, setLeagues] = useState([]);
     const [selectedLeague, setSelectedLeague] = useState('');
     const [showModal, setShowModal] = useState(false);
@@ -24,7 +24,6 @@ function JoinLeague() {
     const [error, setError] = useState('');
 
     const [showFilter, setShowFilter] = useState(false);
-    const [useFilter, setUseFilter] = useState(false);
     const [nameFilter, setNameFilter] = useState('');
     const [visFilter, setVisFilter] = useState('Both');
     const [minTradeLimitFilter, setMinTradeLimitFilter] = useState(null);
@@ -36,6 +35,7 @@ function JoinLeague() {
     const [earlyEndFilter, setEarlyEndFilter] = useState('');
     const [lateEndFilter, setLateEndFilter] = useState('');
     const [hideFull, setHideFull] = useState(false);
+    const [hideJoined, setHideJoined] = useState(false);
 
     const [ascending, setReversed] = useState(false);
     const [currentSort, setCurrentSort] = useState('');
@@ -45,9 +45,8 @@ function JoinLeague() {
 
     const resetFilter = () => {
         setShowFilter(false);
-        setUseFilter(false);
         setNameFilter('');
-        setVisFilter('Both');
+        setVisFilter('both');
 
         setMinTradeLimitFilter(null);
         setMaxTradeLimitFilter(null);
@@ -60,6 +59,65 @@ function JoinLeague() {
         setLateEndFilter('');
 
         setHideFull(false);
+        setHideJoined(false);
+        setLeagues(allLeagues);
+    };
+
+    const applyFilter = () => {
+        const list = allLeagues;
+        const filteredLeagues = list.filter((league) => {
+            /*
+            *   if (filterIsUsed && !(filterSatified)) {
+            *       return false;
+            *   }
+            */
+            if (nameFilter.length !== 0 && !league.leagueName.includes(nameFilter)) {
+                return false;
+            }
+            if ((visFilter === 'public' && !league.settings.public)) {
+                return false;
+            }
+            if ((visFilter === 'private' && league.settings.public)) {
+                return false;
+            }
+
+            if (minTradeLimitFilter && !(league.settings.tradeLimit >= minTradeLimitFilter)) {
+                return false;
+            }
+            if (maxTradeLimitFilter && !(league.settings.tradeLimit <= maxTradeLimitFilter)) {
+                return false;
+            }
+
+            if (minBalanceFilter && !(league.settings.balance >= minBalanceFilter)) {
+                return false;
+            }
+            if (maxBalanceFilter && !(league.settings.balance <= maxBalanceFilter)) {
+                return false;
+            }
+
+            if (earlyStartFilter && !(league.settings.startDate >= earlyStartFilter)) {
+                return false;
+            }
+            if (lateStartFilter && !(league.settings.startDate <= lateStartFilter)) {
+                return false;
+            }
+            if (earlyEndFilter && !(league.settings.endDate >= earlyEndFilter)) {
+                return false;
+            }
+            if (lateEndFilter && !(league.settings.endDate <= lateEndFilter)) {
+                return false;
+            }
+
+            if (hideFull && !(league.playerList.length < league.settings.maxPlayers)) {
+                return false;
+            }
+            if (hideJoined && league.playerList.includes(username)) {
+                return false;
+            }
+
+            return true;
+        });
+        setLeagues(filteredLeagues);
     };
 
     const joinLeague = (league) => {
@@ -111,8 +169,9 @@ function JoinLeague() {
     };
 
     const loadLeagues = async () => {
-        setLeagues(await getLeagues());
-        console.log(leagues);
+        const reqLeagues = await getLeagues();
+        setLeagues(reqLeagues);
+        setAllLeagues(reqLeagues);
     };
 
     useEffect(() => {
@@ -255,15 +314,11 @@ function JoinLeague() {
         nameSort();
     }
 
-    console.log(currentSort);
-    console.log(ascending);
-
     return (
         <div>
             <div>
                 <Button onClick={() => {
                     setShowFilter(true);
-                    setUseFilter(false);
                 }}
                 >
                     Set New Filters
@@ -358,7 +413,6 @@ function JoinLeague() {
                                                     </div>
                                                 );
                                             }
-                                            console.log('success');
                                             return league.leagueName;
                                         }
                                         )()}
@@ -468,25 +522,18 @@ function JoinLeague() {
                                 </div>
                             </Form.Group>
 
-                            <Form.Group controlId="formHide">
+                            <Form.Group controlId="formHideFull">
                                 <Form.Check type="checkbox" label="Hide Full Leagues" defaultChecked={hideFull} onChange={() => setHideFull(!hideFull)} />
+                            </Form.Group>
+                            <Form.Group controlId="formHideJoined">
+                                <Form.Check type="checkbox" label="Hide Joined Leagues" defaultChecked={hideJoined} onChange={() => setHideJoined(!hideJoined)} />
                             </Form.Group>
 
                             <center>
                                 <Button onClick={() => {
-                                    setUseFilter(true);
-                                    console.log(nameFilter);
-                                    console.log(useFilter);
-                                    console.log(visFilter);
-                                    console.log(minBalanceFilter);
-                                    console.log(maxBalanceFilter);
-                                    console.log(earlyStartFilter);
-                                    console.log(lateStartFilter);
-                                    console.log(earlyEndFilter);
-                                    console.log(lateEndFilter);
-                                    console.log(hideFull);
-                                    console.log(minTradeLimitFilter);
-                                    console.log(maxTradeLimitFilter);
+                                    applyFilter();
+                                    console.log('Saved');
+                                    handleFilterClose();
                                 }}
                                 >Set New Filter
                                 </Button>

--- a/frontend/src/components/JoinLeague/JoinLeague.js
+++ b/frontend/src/components/JoinLeague/JoinLeague.js
@@ -261,8 +261,12 @@ function JoinLeague() {
     return (
         <div>
             <div>
-                <Button onClick={() => setShowFilter(true)}>
-                    Set Filters
+                <Button onClick={() => {
+                    setShowFilter(true);
+                    setUseFilter(false);
+                }}
+                >
+                    Set New Filters
                 </Button>
             </div>
             <div>

--- a/frontend/src/components/JoinLeague/JoinLeague.js
+++ b/frontend/src/components/JoinLeague/JoinLeague.js
@@ -495,22 +495,32 @@ function JoinLeague() {
                                 </Form.Control>
                             </Form.Group>
                             <Form.Group className="filter-form-field-container" controlId="formTradeLimit">
-                                <Form.Label className="filter-form-title">Trade Limit Range</Form.Label>
-                                <Form.Control className="filter-form-fields" type="number" placeholder="0" defaultValue={minTradeLimitFilter} onChange={(e) => setMinTradeLimitFilter(e.target.value)} />
-                                to
-                                <Form.Control className="filter-form-fields" type="number" placeholder="0" defaultValue={maxTradeLimitFilter} onChange={(e) => setMaxTradeLimitFilter(e.target.value)} />
+                                <div className="filter-form-title">
+                                    <Form.Label>Trade Limit Range</Form.Label>
+                                </div>
+                                <div className="range">
+                                    <Form.Control className="filter-form-fields" type="number" placeholder="0" defaultValue={minTradeLimitFilter} onChange={(e) => setMinTradeLimitFilter(e.target.value)} />
+                                    <div className="spacing-between-fields">to</div>
+                                    <Form.Control className="filter-form-fields" type="number" placeholder="0" defaultValue={maxTradeLimitFilter} onChange={(e) => setMaxTradeLimitFilter(e.target.value)} />
+                                </div>
                             </Form.Group>
                             <Form.Group className="filter-form-field-container" controlId="formBalance">
-                                <Form.Label className="filter-form-title">Start Balance Range</Form.Label>
-                                <Form.Control className="filter-form-fields" type="number" placeholder="500" defaultValue={minBalanceFilter} onChange={(e) => setMinBalanceFilter(e.target.value)} />
-                                to
-                                <Form.Control className="filter-form-fields" type="number" placeholder="500" defaultValue={maxBalanceFilter} onChange={(e) => setMaxBalanceFilter(e.target.value)} />
+                                <div className="filter-form-title">
+                                    <Form.Label>Start Balance Range</Form.Label>
+                                </div>
+                                <div className="range">
+                                    <Form.Control className="filter-form-fields" type="number" placeholder="0" defaultValue={minBalanceFilter} onChange={(e) => setMinBalanceFilter(e.target.value)} />
+                                    <div className="spacing-between-fields">to</div>
+                                    <Form.Control className="filter-form-fields" type="number" placeholder="0" defaultValue={maxBalanceFilter} onChange={(e) => setMaxBalanceFilter(e.target.value)} />
+                                </div>
                             </Form.Group>
                             <Form.Group className="filter-form-field-container" controlId="formStart">
-                                <Form.Label className="filter-form-title">Start Date Range</Form.Label>
+                                <div className="filter-form-title">
+                                    <Form.Label>Start Date Range</Form.Label>
+                                </div>
                                 <div className="range">
                                     <Form.Control className="filter-form-fields" type="date" placeholder="01/01/2021" defaultValue={earlyStartFilter} onChange={(e) => setEarlyStartFilter(e.target.value)} />
-                                    to
+                                    <div className="spacing-between-fields">to</div>
                                     <Form.Control className="filter-form-fields" type="date" placeholder="01/01/2021" defaultValue={lateStartFilter} onChange={(e) => setLateStartFilter(e.target.value)} />
                                 </div>
                             </Form.Group>
@@ -518,7 +528,7 @@ function JoinLeague() {
                                 <Form.Label className="filter-form-title">End Date Range</Form.Label>
                                 <div className="range">
                                     <Form.Control className="filter-form-fields" type="date" placeholder="01/01/2021" defaultValue={earlyEndFilter} onChange={(e) => setEarlyEndFilter(e.target.value)} />
-                                    to
+                                    <div className="spacing-between-fields">to</div>
                                     <Form.Control className="filter-form-fields" type="date" placeholder="01/01/2021" defaultValue={lateEndFilter} onChange={(e) => setLateEndFilter(e.target.value)} />
                                 </div>
                             </Form.Group>

--- a/frontend/src/components/JoinLeague/JoinLeague.js
+++ b/frontend/src/components/JoinLeague/JoinLeague.js
@@ -33,8 +33,8 @@ function JoinLeague() {
     const [earlyEndFilter, setEarlyEndFilter] = useState('');
     const [lateEndFilter, setLateEndFilter] = useState('');
 
-    const [reversed, setReversed] = useState(false);
-    const [currentSort, setCurrentSort] = useState('name');
+    const [ascending, setReversed] = useState(false);
+    const [currentSort, setCurrentSort] = useState('');
 
     const handleClose = () => setShowModal(false);
     const handleFilterClose = () => setShowFilter(false);
@@ -96,7 +96,14 @@ function JoinLeague() {
         loadLeagues();
     }, []);
 
-    const nameSort = (reverse) => {
+    const nameSort = () => {
+        if (currentSort === 'name') {
+            setReversed(!ascending);
+        } else {
+            setReversed(false);
+            setCurrentSort('name');
+        }
+
         if (leagues) {
             leagues.sort((a, b) => {
                 if (a.leagueName.toLowerCase() > b.leagueName.toLowerCase()) {
@@ -105,20 +112,20 @@ function JoinLeague() {
                 return -1;
             });
 
-            if (reverse) {
+            if (ascending) {
                 leagues.reverse();
             }
         }
-
-        if (currentSort === 'name') {
-            setReversed(!reversed);
-        } else {
-            setReversed(false);
-            setCurrentSort('name');
-        }
     };
 
-    const startingBalanceSort = (reverse) => {
+    const startingBalanceSort = () => {
+        if (currentSort === 'balance') {
+            setReversed(!ascending);
+        } else {
+            setReversed(false);
+            setCurrentSort('balance');
+        }
+
         if (leagues) {
             leagues.sort((a, b) => {
                 if (a.settings.balance > b.settings.balance) {
@@ -127,20 +134,20 @@ function JoinLeague() {
                 return -1;
             });
 
-            if (reverse) {
+            if (ascending) {
                 leagues.reverse();
             }
         }
-
-        if (currentSort === 'balance') {
-            setReversed(!reversed);
-        } else {
-            setReversed(false);
-            setCurrentSort('balance');
-        }
     };
 
-    const tradeLimitSort = (reverse) => {
+    const tradeLimitSort = () => {
+        if (currentSort === 'trade') {
+            setReversed(!ascending);
+        } else {
+            setReversed(false);
+            setCurrentSort('trade');
+        }
+
         if (leagues) {
             leagues.sort((a, b) => {
                 if (a.settings.tradeLimit > b.settings.tradeLimit) {
@@ -149,20 +156,20 @@ function JoinLeague() {
                 return -1;
             });
 
-            if (reverse) {
+            if (ascending) {
                 leagues.reverse();
             }
         }
-
-        if (currentSort === 'trade') {
-            setReversed(!reversed);
-        } else {
-            setReversed(false);
-            setCurrentSort('trade');
-        }
     };
 
-    const startDateSort = (reverse) => {
+    const startDateSort = () => {
+        if (currentSort === 'startDate') {
+            setReversed(!ascending);
+        } else {
+            setReversed(false);
+            setCurrentSort('startDate');
+        }
+
         if (leagues) {
             leagues.sort((a, b) => {
                 if (a.settings.startDate > b.settings.startDate) {
@@ -171,20 +178,20 @@ function JoinLeague() {
                 return -1;
             });
 
-            if (reverse) {
+            if (ascending) {
                 leagues.reverse();
             }
         }
-
-        if (currentSort === 'startDate') {
-            setReversed(!reversed);
-        } else {
-            setReversed(false);
-            setCurrentSort('startDate');
-        }
     };
 
-    const endDateSort = (reverse) => {
+    const endDateSort = () => {
+        if (currentSort === 'endDate') {
+            setReversed(!ascending);
+        } else {
+            setReversed(false);
+            setCurrentSort('endDate');
+        }
+
         if (leagues) {
             leagues.sort((a, b) => {
                 if (a.settings.endDate > b.settings.endDate) {
@@ -193,20 +200,20 @@ function JoinLeague() {
                 return -1;
             });
 
-            if (reverse) {
+            if (ascending) {
                 leagues.reverse();
             }
         }
-
-        if (currentSort === 'endDate') {
-            setReversed(!reversed);
-        } else {
-            setReversed(false);
-            setCurrentSort('endDate');
-        }
     };
 
-    const visibilitySort = (reverse) => {
+    const visibilitySort = () => {
+        if (currentSort === 'vis') {
+            setReversed(!ascending);
+        } else {
+            setReversed(false);
+            setCurrentSort('vis');
+        }
+
         if (leagues) {
             leagues.sort((a, b) => {
                 if (a.settings.public > b.settings.public) {
@@ -215,22 +222,18 @@ function JoinLeague() {
                 return -1;
             });
 
-            if (reverse) {
+            if (ascending) {
                 leagues.reverse();
             }
         }
-
-        if (currentSort === 'vis') {
-            setReversed(!reversed);
-        } else {
-            setReversed(false);
-            setCurrentSort('vis');
-        }
     };
 
-    // visibilitySort(true);
-    // startingBalanceSort(reversed);
-    // nameSort(reversed);
+    if (currentSort === '') {
+        nameSort();
+    }
+
+    console.log(currentSort);
+    console.log(ascending);
 
     return (
         <div>
@@ -262,35 +265,35 @@ function JoinLeague() {
                         <thead>
                             <tr>
                                 <th>League Name
-                                    <Button onClick={() => nameSort(reversed)} className="filter-button">
+                                    <Button onClick={() => nameSort()} className="filter-button">
                                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
                                             <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
                                         </svg>
                                     </Button>
                                 </th>
                                 <th>Starting Balance
-                                    <Button onClick={() => startingBalanceSort(reversed)} className="filter-button">
+                                    <Button onClick={() => startingBalanceSort()} className="filter-button">
                                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
                                             <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
                                         </svg>
                                     </Button>
                                 </th>
                                 <th>Trade Limit
-                                    <Button onClick={() => tradeLimitSort(reversed)} className="filter-button">
+                                    <Button onClick={() => tradeLimitSort()} className="filter-button">
                                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
                                             <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
                                         </svg>
                                     </Button>
                                 </th>
                                 <th>Start Date
-                                    <Button onClick={() => startDateSort(reversed)} className="filter-button">
+                                    <Button onClick={() => startDateSort()} className="filter-button">
                                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
                                             <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
                                         </svg>
                                     </Button>
                                 </th>
                                 <th>End Date
-                                    <Button onClick={() => endDateSort(reversed)} className="filter-button">
+                                    <Button onClick={() => endDateSort()} className="filter-button">
                                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
                                             <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
                                         </svg>
@@ -298,7 +301,7 @@ function JoinLeague() {
                                 </th>
                                 <th>Members</th>
                                 <th>Type
-                                    <Button onClick={() => visibilitySort(reversed)} className="filter-button">
+                                    <Button onClick={() => visibilitySort()} className="filter-button">
                                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
                                             <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
                                         </svg>

--- a/frontend/src/components/JoinLeague/JoinLeague.js
+++ b/frontend/src/components/JoinLeague/JoinLeague.js
@@ -24,20 +24,43 @@ function JoinLeague() {
     const [error, setError] = useState('');
 
     const [showFilter, setShowFilter] = useState(false);
+    const [useFilter, setUseFilter] = useState(false);
     const [nameFilter, setNameFilter] = useState('');
     const [visFilter, setVisFilter] = useState('Both');
-    const [minBalanceFilter, setMinBalanceFilter] = useState(0);
-    const [maxBalanceFilter, setMaxBalanceFilter] = useState(0);
+    const [minTradeLimitFilter, setMinTradeLimitFilter] = useState(null);
+    const [maxTradeLimitFilter, setMaxTradeLimitFilter] = useState(null);
+    const [minBalanceFilter, setMinBalanceFilter] = useState(null);
+    const [maxBalanceFilter, setMaxBalanceFilter] = useState(null);
     const [earlyStartFilter, setEarlyStartFilter] = useState('');
     const [lateStartFilter, setLateStartFilter] = useState('');
     const [earlyEndFilter, setEarlyEndFilter] = useState('');
     const [lateEndFilter, setLateEndFilter] = useState('');
+    const [hideFull, setHideFull] = useState(false);
 
     const [ascending, setReversed] = useState(false);
     const [currentSort, setCurrentSort] = useState('');
 
     const handleClose = () => setShowModal(false);
     const handleFilterClose = () => setShowFilter(false);
+
+    const resetFilter = () => {
+        setShowFilter(false);
+        setUseFilter(false);
+        setNameFilter('');
+        setVisFilter('Both');
+
+        setMinTradeLimitFilter(null);
+        setMaxTradeLimitFilter(null);
+        setMinBalanceFilter(null);
+        setMaxBalanceFilter(null);
+
+        setEarlyStartFilter('');
+        setLateStartFilter('');
+        setEarlyEndFilter('');
+        setLateEndFilter('');
+
+        setHideFull(false);
+    };
 
     const joinLeague = (league) => {
         fetch(`${process.env.REACT_APP_LAPI_URL}/league/join`, {
@@ -242,6 +265,11 @@ function JoinLeague() {
                     Set Filters
                 </Button>
             </div>
+            <div>
+                <Button onClick={() => resetFilter()}>
+                    Reset Filters
+                </Button>
+            </div>
             <Container style={{ marginLeft: '8vw' }} className="join-league-container">
                 <div className="join-league-form-title">
                     Join a League
@@ -397,52 +425,68 @@ function JoinLeague() {
                         <Form className="filter-form">
                             <Form.Group controlId="formLeagueName">
                                 <Form.Label>League Name</Form.Label>
-                                <Form.Control type="text" placeholder="Name" onChange={(e) => setNameFilter(e.target.value)} />
+                                <Form.Control type="text" placeholder="Name" defaultValue={nameFilter} onChange={(e) => setNameFilter(e.target.value)} />
                             </Form.Group>
                             <Form.Group controlId="formVisibility">
                                 <Form.Label>Visibility</Form.Label>
-                                <Form.Control as="select" onChange={(e) => setVisFilter(e.target.value)}>
+                                <Form.Control as="select" defaultValue={visFilter} onChange={(e) => setVisFilter(e.target.value)}>
                                     <option value="both">Both</option>
                                     <option value="public">Public</option>
                                     <option value="private">Private</option>
                                 </Form.Control>
                             </Form.Group>
-
+                            <Form.Group controlId="formTradeLimit">
+                                <Form.Label>Trade Limit Range</Form.Label>
+                                <Form.Control type="number" placeholder="0" defaultValue={minTradeLimitFilter} onChange={(e) => setMinTradeLimitFilter(e.target.value)} />
+                                to
+                                <Form.Control type="number" placeholder="0" defaultValue={maxTradeLimitFilter} onChange={(e) => setMaxTradeLimitFilter(e.target.value)} />
+                            </Form.Group>
                             <Form.Group controlId="formBalance">
                                 <Form.Label>Start Balance Range</Form.Label>
-                                <Form.Control type="number" placeholder="500" onChange={(e) => setMinBalanceFilter(e.target.value)} />
+                                <Form.Control type="number" placeholder="500" defaultValue={minBalanceFilter} onChange={(e) => setMinBalanceFilter(e.target.value)} />
                                 to
-                                <Form.Control type="number" placeholder="500" onChange={(e) => setMaxBalanceFilter(e.target.value)} />
+                                <Form.Control type="number" placeholder="500" defaultValue={maxBalanceFilter} onChange={(e) => setMaxBalanceFilter(e.target.value)} />
                             </Form.Group>
                             <Form.Group controlId="formStart">
                                 <Form.Label>Start Date Range</Form.Label>
                                 <div className="range">
-                                    <Form.Control type="date" placeholder="01/01/2021" onChange={(e) => setEarlyStartFilter(e.target.value)} />
+                                    <Form.Control type="date" placeholder="01/01/2021" defaultValue={earlyStartFilter} onChange={(e) => setEarlyStartFilter(e.target.value)} />
                                     to
-                                    <Form.Control type="date" placeholder="01/01/2021" onChange={(e) => setLateStartFilter(e.target.value)} />
+                                    <Form.Control type="date" placeholder="01/01/2021" defaultValue={lateStartFilter} onChange={(e) => setLateStartFilter(e.target.value)} />
                                 </div>
                             </Form.Group>
-                            <Form.Group controlId="formEarlyEnd">
+                            <Form.Group controlId="formEnd">
                                 <Form.Label>End Date Range</Form.Label>
                                 <div className="range">
-                                    <Form.Control type="date" placeholder="01/01/2021" onChange={(e) => setEarlyEndFilter(e.target.value)} />
+                                    <Form.Control type="date" placeholder="01/01/2021" defaultValue={earlyEndFilter} onChange={(e) => setEarlyEndFilter(e.target.value)} />
                                     to
-                                    <Form.Control type="date" placeholder="01/01/2021" onChange={(e) => setLateEndFilter(e.target.value)} />
+                                    <Form.Control type="date" placeholder="01/01/2021" defaultValue={lateEndFilter} onChange={(e) => setLateEndFilter(e.target.value)} />
                                 </div>
                             </Form.Group>
 
-                            <Button onClick={() => {
-                                console.log(nameFilter);
-                                console.log(visFilter);
-                                console.log(minBalanceFilter);
-                                console.log(maxBalanceFilter);
-                                console.log(earlyStartFilter);
-                                console.log(lateStartFilter);
-                                console.log(earlyEndFilter);
-                                console.log(lateEndFilter);
-                            }}
-                            >Save
-                            </Button>
+                            <Form.Group controlId="formHide">
+                                <Form.Check type="checkbox" label="Hide Full Leagues" defaultChecked={hideFull} onChange={() => setHideFull(!hideFull)} />
+                            </Form.Group>
+
+                            <center>
+                                <Button onClick={() => {
+                                    setUseFilter(true);
+                                    console.log(nameFilter);
+                                    console.log(useFilter);
+                                    console.log(visFilter);
+                                    console.log(minBalanceFilter);
+                                    console.log(maxBalanceFilter);
+                                    console.log(earlyStartFilter);
+                                    console.log(lateStartFilter);
+                                    console.log(earlyEndFilter);
+                                    console.log(lateEndFilter);
+                                    console.log(hideFull);
+                                    console.log(minTradeLimitFilter);
+                                    console.log(maxTradeLimitFilter);
+                                }}
+                                >Set New Filter
+                                </Button>
+                            </center>
                         </Form>
                     </Modal.Body>
                 </Modal>

--- a/frontend/src/components/JoinLeague/JoinLeague.js
+++ b/frontend/src/components/JoinLeague/JoinLeague.js
@@ -23,7 +23,21 @@ function JoinLeague() {
     const [showError, setShowError] = useState(false);
     const [error, setError] = useState('');
 
+    const [showFilter, setShowFilter] = useState(false);
+    const [nameFilter, setNameFilter] = useState('');
+    const [visFilter, setVisFilter] = useState('Both');
+    const [minBalanceFilter, setMinBalanceFilter] = useState(0);
+    const [maxBalanceFilter, setMaxBalanceFilter] = useState(0);
+    const [earlyStartFilter, setEarlyStartFilter] = useState('');
+    const [lateStartFilter, setLateStartFilter] = useState('');
+    const [earlyEndFilter, setEarlyEndFilter] = useState('');
+    const [lateEndFilter, setLateEndFilter] = useState('');
+
+    const [reversed, setReversed] = useState(false);
+    const [currentSort, setCurrentSort] = useState('name');
+
     const handleClose = () => setShowModal(false);
+    const handleFilterClose = () => setShowFilter(false);
 
     const joinLeague = (league) => {
         fetch(`${process.env.REACT_APP_LAPI_URL}/league/join`, {
@@ -82,9 +96,150 @@ function JoinLeague() {
         loadLeagues();
     }, []);
 
+    const nameSort = (reverse) => {
+        if (leagues) {
+            leagues.sort((a, b) => {
+                if (a.leagueName.toLowerCase() > b.leagueName.toLowerCase()) {
+                    return 1;
+                }
+                return -1;
+            });
+
+            if (reverse) {
+                leagues.reverse();
+            }
+        }
+
+        if (currentSort === 'name') {
+            setReversed(!reversed);
+        } else {
+            setReversed(false);
+            setCurrentSort('name');
+        }
+    };
+
+    const startingBalanceSort = (reverse) => {
+        if (leagues) {
+            leagues.sort((a, b) => {
+                if (a.settings.balance > b.settings.balance) {
+                    return 1;
+                }
+                return -1;
+            });
+
+            if (reverse) {
+                leagues.reverse();
+            }
+        }
+
+        if (currentSort === 'balance') {
+            setReversed(!reversed);
+        } else {
+            setReversed(false);
+            setCurrentSort('balance');
+        }
+    };
+
+    const tradeLimitSort = (reverse) => {
+        if (leagues) {
+            leagues.sort((a, b) => {
+                if (a.settings.tradeLimit > b.settings.tradeLimit) {
+                    return 1;
+                }
+                return -1;
+            });
+
+            if (reverse) {
+                leagues.reverse();
+            }
+        }
+
+        if (currentSort === 'trade') {
+            setReversed(!reversed);
+        } else {
+            setReversed(false);
+            setCurrentSort('trade');
+        }
+    };
+
+    const startDateSort = (reverse) => {
+        if (leagues) {
+            leagues.sort((a, b) => {
+                if (a.settings.startDate > b.settings.startDate) {
+                    return 1;
+                }
+                return -1;
+            });
+
+            if (reverse) {
+                leagues.reverse();
+            }
+        }
+
+        if (currentSort === 'startDate') {
+            setReversed(!reversed);
+        } else {
+            setReversed(false);
+            setCurrentSort('startDate');
+        }
+    };
+
+    const endDateSort = (reverse) => {
+        if (leagues) {
+            leagues.sort((a, b) => {
+                if (a.settings.endDate > b.settings.endDate) {
+                    return 1;
+                }
+                return -1;
+            });
+
+            if (reverse) {
+                leagues.reverse();
+            }
+        }
+
+        if (currentSort === 'endDate') {
+            setReversed(!reversed);
+        } else {
+            setReversed(false);
+            setCurrentSort('endDate');
+        }
+    };
+
+    const visibilitySort = (reverse) => {
+        if (leagues) {
+            leagues.sort((a, b) => {
+                if (a.settings.public > b.settings.public) {
+                    return 1;
+                }
+                return -1;
+            });
+
+            if (reverse) {
+                leagues.reverse();
+            }
+        }
+
+        if (currentSort === 'vis') {
+            setReversed(!reversed);
+        } else {
+            setReversed(false);
+            setCurrentSort('vis');
+        }
+    };
+
+    // visibilitySort(true);
+    // startingBalanceSort(reversed);
+    // nameSort(reversed);
+
     return (
         <div>
-            <Container className="join-league-container">
+            <div>
+                <Button onClick={() => setShowFilter(true)}>
+                    Set Filters
+                </Button>
+            </div>
+            <Container style={{ marginLeft: '8vw' }} className="join-league-container">
                 <div className="join-league-form-title">
                     Join a League
                 </div>
@@ -102,14 +257,53 @@ function JoinLeague() {
                             {error}
                         </Alert>
                     )}
-                <Form className="join-league-form">
+                <Form className="join-league-form" style={{ width: '75vw' }}>
                     <Table striped bordered variant="light">
                         <thead>
                             <tr>
-                                <th>League Name</th>
-                                <th>End Date</th>
+                                <th>League Name
+                                    <Button onClick={() => nameSort(reversed)} className="filter-button">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
+                                            <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
+                                        </svg>
+                                    </Button>
+                                </th>
+                                <th>Starting Balance
+                                    <Button onClick={() => startingBalanceSort(reversed)} className="filter-button">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
+                                            <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
+                                        </svg>
+                                    </Button>
+                                </th>
+                                <th>Trade Limit
+                                    <Button onClick={() => tradeLimitSort(reversed)} className="filter-button">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
+                                            <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
+                                        </svg>
+                                    </Button>
+                                </th>
+                                <th>Start Date
+                                    <Button onClick={() => startDateSort(reversed)} className="filter-button">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
+                                            <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
+                                        </svg>
+                                    </Button>
+                                </th>
+                                <th>End Date
+                                    <Button onClick={() => endDateSort(reversed)} className="filter-button">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
+                                            <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
+                                        </svg>
+                                    </Button>
+                                </th>
                                 <th>Members</th>
-                                <th>Type</th>
+                                <th>Type
+                                    <Button onClick={() => visibilitySort(reversed)} className="filter-button">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="var(--dark-grey-scale)" className="filter" viewBox="0 0 16 16">
+                                            <path d="M6 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-2-3a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11a.5.5 0 0 1-.5-.5z" />
+                                        </svg>
+                                    </Button>
+                                </th>
                                 <th>Join</th>
                             </tr>
                         </thead>
@@ -133,6 +327,16 @@ function JoinLeague() {
                                             return league.leagueName;
                                         }
                                         )()}
+                                        </td>
+                                        <td>
+                                            {(() => (<div>{league.settings.balance}</div>))()}
+                                        </td>
+                                        <td>
+                                            {(() => (<div>{league.settings.tradeLimit}</div>))()}
+                                        </td>
+                                        <td>
+                                            {`${new Date(league.settings.startDate).getMonth() + 1
+                                            }/${new Date(league.settings.startDate).getDate() + 1}/${new Date(league.settings.startDate).getFullYear()}`}
                                         </td>
                                         <td>
                                             {`${new Date(league.settings.endDate).getMonth() + 1
@@ -178,6 +382,64 @@ function JoinLeague() {
                             </Form.Group>
 
                             <Button onClick={() => joinLeague(selectedLeague)}>Join</Button>
+                        </Form>
+                    </Modal.Body>
+                </Modal>
+
+                <Modal show={showFilter} onHide={handleFilterClose} centered>
+                    <Modal.Header closeButton>
+                        <Modal.Title> Filter Preferences </Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <Form className="filter-form">
+                            <Form.Group controlId="formLeagueName">
+                                <Form.Label>League Name</Form.Label>
+                                <Form.Control type="text" placeholder="Name" onChange={(e) => setNameFilter(e.target.value)} />
+                            </Form.Group>
+                            <Form.Group controlId="formVisibility">
+                                <Form.Label>Visibility</Form.Label>
+                                <Form.Control as="select" onChange={(e) => setVisFilter(e.target.value)}>
+                                    <option value="both">Both</option>
+                                    <option value="public">Public</option>
+                                    <option value="private">Private</option>
+                                </Form.Control>
+                            </Form.Group>
+
+                            <Form.Group controlId="formBalance">
+                                <Form.Label>Start Balance Range</Form.Label>
+                                <Form.Control type="number" placeholder="500" onChange={(e) => setMinBalanceFilter(e.target.value)} />
+                                to
+                                <Form.Control type="number" placeholder="500" onChange={(e) => setMaxBalanceFilter(e.target.value)} />
+                            </Form.Group>
+                            <Form.Group controlId="formStart">
+                                <Form.Label>Start Date Range</Form.Label>
+                                <div className="range">
+                                    <Form.Control type="date" placeholder="01/01/2021" onChange={(e) => setEarlyStartFilter(e.target.value)} />
+                                    to
+                                    <Form.Control type="date" placeholder="01/01/2021" onChange={(e) => setLateStartFilter(e.target.value)} />
+                                </div>
+                            </Form.Group>
+                            <Form.Group controlId="formEarlyEnd">
+                                <Form.Label>End Date Range</Form.Label>
+                                <div className="range">
+                                    <Form.Control type="date" placeholder="01/01/2021" onChange={(e) => setEarlyEndFilter(e.target.value)} />
+                                    to
+                                    <Form.Control type="date" placeholder="01/01/2021" onChange={(e) => setLateEndFilter(e.target.value)} />
+                                </div>
+                            </Form.Group>
+
+                            <Button onClick={() => {
+                                console.log(nameFilter);
+                                console.log(visFilter);
+                                console.log(minBalanceFilter);
+                                console.log(maxBalanceFilter);
+                                console.log(earlyStartFilter);
+                                console.log(lateStartFilter);
+                                console.log(earlyEndFilter);
+                                console.log(lateEndFilter);
+                            }}
+                            >Save
+                            </Button>
                         </Form>
                     </Modal.Body>
                 </Modal>

--- a/frontend/src/components/News/Sections/Articles.js
+++ b/frontend/src/components/News/Sections/Articles.js
@@ -9,8 +9,8 @@ const Articles = (props) => {
         <Container className="articles-container">
             {articles.map((article) => (
                 <div className="article">
-                    <Card>
-                        <Card.Img variant="top" src={article.image} />
+                    <Card className="article-cards">
+                        <Card.Img className="article-image-cards" variant="top" src={article.image} />
                         <Card.Body>
                             <Card.Title className="article-headline">{article.headline}</Card.Title>
                             <Card.Text>

--- a/frontend/src/styles/JoinLeague/JoinLeague.scss
+++ b/frontend/src/styles/JoinLeague/JoinLeague.scss
@@ -56,29 +56,16 @@
 
 .filter-form-field-container{
     display: flex;
+    flex-direction: column;
 
-    .filter-form-fields{
+    .range{
         display: inherit;
         flex-direction: row;
     }
 }
 
-.Modal{
-    width: 850px !important;
-  }
-
-.range{
-    display: flex;
-
-    .filter-form-title{
-        display: inherit;
-        flex-direction: column;
-    }
-
-    .filter-form-fields{
-        display: inherit;
-        flex-direction: row;
-    }
+.spacing-between-fields{
+    margin: 0.6vh 1vw 0vh 1vw;
 }
 
 .private-league-form{

--- a/frontend/src/styles/JoinLeague/JoinLeague.scss
+++ b/frontend/src/styles/JoinLeague/JoinLeague.scss
@@ -19,12 +19,19 @@
 }
 
 .join-league-form{
-    min-width: 800px;
+   // min-width: 800px;
     overflow: auto;
     margin-bottom: 100px;
     .btn {
         @include btn;
     }
+}
+
+.filter-button{
+    background-color: white !important;
+    border: none !important;
+    margin-left: 0.5vw;
+    padding: 0.10rem 0.25rem !important;
 }
 
 .private-league-form{

--- a/frontend/src/styles/News/News.scss
+++ b/frontend/src/styles/News/News.scss
@@ -1,9 +1,13 @@
+:root{
+    .site-content{
+        margin-right: 0px;
+    }
+}
+
 .news-title{
     color: white;
     font-size: 35px;
-    margin-left: 15px;
-    padding-top: 30px;
-    padding-bottom: 30px;
+    margin: 5vh 0vw 5vh 1vw;
 }
 
 .news-container {
@@ -13,19 +17,20 @@
 }
 
 .news-dropdown {
-    margin-left: 15px;
+    margin-left: 1vw;
+
     .btn{
-        color: black;
-        background-color: white;
-        border-color: white;
+        color: white;
+        background-color: var(--mint);
+        border-color: var(--mint);
         &:hover, &:focus, &:active{
-            color: black;
-            background-color: white;
+            color: white;
+            background-color: var(--mint);
             border-color: white;
         }
         &:not(:disabled):not(.disabled) {
-            background: white;
-            color: black;
+            background: var(--mint);
+            color: white;
         }
     }
 }
@@ -37,9 +42,19 @@
 }
 
 .article {
-    padding: 50px;
-    width: 500px;
-    height: 400px;
+    width: 300px;
+    height: 345px;
+    margin: 2vh 0vw 8vh 3vw;
+}
+
+.article-cards {
+    width: 300px;
+    height: 345px;
+}
+
+.article-image-cards{
+    width: 297px;
+    height: 215px;
 }
 
 .article-headline {


### PR DESCRIPTION
This PR addresses the filtering issue on the Join League Page. The user will be given two filtering options. One of the options will be sorting each column in ascending or descending order. The other filtering option will be a button that the user can click to more thoroughly filter through all the join league options. This PR closes #89 and below are the corresponding pictures.

**Filtering Columns:** 
![Filter Join League Columns](https://user-images.githubusercontent.com/52171753/115161714-3d953480-a06d-11eb-9682-9caf165e7d74.jpg)

**Filter Pop Up:**
<img width="1440" alt="Modal updated" src="https://user-images.githubusercontent.com/52171753/115578778-9219f900-a293-11eb-9d5e-f92d25f4d484.png">

This PR also closes #123. Regarding the NewsPage the changes made are listed below as well as the updated look: 
- Overrode site-content class in root.scss to allow articles to extend to a third column. 
- Changed sizing of Card.Img & Card to keep consistent sizing for every article.
- Changed Button to match consistent theme of mint throughout application.
- Changed sizing from px to vh & vw to allow for a better viewing experience on different screen sizes.

**NewsPage:** 
<img width="1440" alt="News Page" src="https://user-images.githubusercontent.com/52171753/115608983-f6998000-a2b4-11eb-956e-8f2e230a5c5a.png">

**Bug Fixes:**
- Trade.js uses 'tickerSymbol' instead of 'ticker' (may already be fixed).
- Fixed createLeague max player discrepancy 
- Fixed joinLeague issue where Success and Fail messages appear simultaneously

*There is a small bug when you filter one column and move onto another column, the first click reorganizes the rest of the table to match the ordering of the column being organizes. Then you have to click twice to reverse the order of the column instead of just once. Not sure what's causing this, but if there is time we should address this.