### PR TITLE
Fixed underlying styling issues for multiple pages

### DIFF
--- a/frontend/src/components/JoinLeague/JoinLeague.js
+++ b/frontend/src/components/JoinLeague/JoinLeague.js
@@ -318,7 +318,7 @@ function JoinLeague() {
 
     return (
         <div className="join-league-page-container">
-            <Container style={{ marginLeft: '8vw' }} className="join-league-container">
+            <Container className="join-league-container">
                 <div className="join-league-form-title">
                     Join a League
                 </div>

--- a/frontend/src/styles/CreateLeague/CreateLeague.scss
+++ b/frontend/src/styles/CreateLeague/CreateLeague.scss
@@ -7,6 +7,7 @@
 
 .create-league-container{
     font-size: 18px;
+    margin-bottom: 10vh;
 }
 
 .create-league-form-title {
@@ -21,7 +22,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: 90px; 
+    margin: 11vh 0px;
     .form-group {
         @extend %flex-center;
         color: white;

--- a/frontend/src/styles/Login/Login.scss
+++ b/frontend/src/styles/Login/Login.scss
@@ -1,46 +1,40 @@
 @import '../root.scss';
 @import '../Button.scss';
 
-.container{
-    height: auto; 
-}
-
 .login-form-title{
     padding-top: 30px;
     color: white;
     text-align: center;
     height: 0px;
     font-size: 35px;
-    margin-left: 250px;
 }
 
 .login-container{
     display: flex;
     flex-direction: column;
-    justify-content: center
-}
+    justify-content: center;
 
-.login-form{ 
-    @extend %flex-center;
-    border-style: solid;
-    border-color: white;
-    margin: 90px auto;
-    margin-left: 250px;
-    padding: 110px 110px;
-    .form-group {
+    .login-form{ 
         @extend %flex-center;
-        color: white;
-        align-items: flex-start;
-    }
-
-    .text-register {
-        &:hover {
-            text-decoration: underline;
+        border-style: solid;
+        border-color: white;
+        margin: 90px auto;
+        padding:70px 110px;
+        .form-group {
+            @extend %flex-center;
+            color: white;
+            align-items: flex-start;
         }
-    }
-
-    .btn {
-        @include btn;
+    
+        .text-register {
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+    
+        .btn {
+            @include btn;
+        }
     }
 }
 

--- a/frontend/src/styles/News/News.scss
+++ b/frontend/src/styles/News/News.scss
@@ -1,9 +1,3 @@
-:root{
-    .site-content{
-        margin-right: 0px;
-    }
-}
-
 .news-title{
     color: white;
     font-size: 35px;

--- a/frontend/src/styles/Registration/Registration.scss
+++ b/frontend/src/styles/Registration/Registration.scss
@@ -1,20 +1,12 @@
 @import '../root.scss';
 @import '../Button.scss';
 
-.testing{
-    justify-content: inherit;
-}
-
 .registration-form-title{
     padding-top: 30px;
     color: white;
     text-align: center;
     height: 0px;
     font-size: 35px;
-}
-
-.registration-container{
-    margin-left: 250px;
 }
 
 .registration-form{ 

--- a/frontend/src/styles/root.scss
+++ b/frontend/src/styles/root.scss
@@ -25,7 +25,6 @@
 
   .site-content {
     width: 100%;
-    margin-right: 250px;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
This PR addressed some styling issues that were unearthed after overriding a root scss line making margin-right: 250px;
I made changes to the following pages:

- In root.scss I removed the margin-right: 250px, which I had found unnecessary when overriding this style in News.scss
- In JoinLeague.js I removed a margin-left, which did not center the page correctly after the above margin was removed.
- In CreateLeague.scss I changed the margins from px to vh for screen sizing & added additional margin spacing at the bottom of the page.
- In Login.scss & Registration.scss I removed margin-right: 250px from multiple locations to center the containers on the page.

All pages should look as they did before, but with proper spacing on all pages. 