### PR TITLE
Integrate league pages, view other user portfolios

### DIFF
--- a/app/services/league/controllers/leagueController.js
+++ b/app/services/league/controllers/leagueController.js
@@ -669,6 +669,7 @@ exports.getPortfolio = async (req, res) => {
                 closePercentChange: (parseFloat(portfolioInfo.closePercentChange) * 100).toFixed(2),
                 holdings: remapHoldings,
                 netWorth: portfolioInfo.netWorth,
+                orders: portfolioInfo.orders,
             };
             res.json(fullResponse);
         });

--- a/app/services/league/routes/leagueRoutes.js
+++ b/app/services/league/routes/leagueRoutes.js
@@ -78,6 +78,8 @@ router.get('/find/:leagueName', leagueController.getLeagueByName);
  */
 router.get('/portfolio/:league', leagueValidation.authValidation, leagueController.getPortfolio);
 
+router.get('/specifiedportfolio/:league/:username', leagueValidation.authValidation, leagueController.getSpecifiedPortfolio);
+
 router.get('/news/:league', leagueValidation.authValidation, leagueController.getPortfolioNews);
 
 router.get('/summary/:leagueName', leagueValidation.authValidation, leagueController.getSummary);

--- a/app/services/league/routes/leagueRoutes.js
+++ b/app/services/league/routes/leagueRoutes.js
@@ -84,6 +84,8 @@ router.get('/news/:league', leagueValidation.authValidation, leagueController.ge
 
 router.get('/summary/:leagueName', leagueValidation.authValidation, leagueController.getSummary);
 
+router.get('/overview/:leagueName', leagueController.getLeagueOverview);
+
 router.post('/insert/:leagueName', leagueValidation.authValidation, leagueController.insertNetWorth);
 
 module.exports = router;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -68,7 +68,7 @@ function App() {
                             <Route path="/summary">
                                 <SummaryPage />
                             </Route>
-                            <Route path="/centralizedLeague">
+                            <Route path="/centralizedleague">
                                 <CentralizedLeaguePage />
                             </Route>
                         </Switch>

--- a/frontend/src/components/CentralizedLeague/CentralizedLeague.js
+++ b/frontend/src/components/CentralizedLeague/CentralizedLeague.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 // import Form from 'react-bootstrap/Form';
 // import Container from 'react-bootstrap/Container';
 import '../../styles/CentralizedLeague/CentralizedLeague.scss';
@@ -10,8 +11,30 @@ import Col from 'react-bootstrap/Col';
 import { Line } from 'react-chartjs-2';
 
 function CentralizedLeague() {
+    const location = useLocation();
+    console.log(location);
+
+    const [league, setLeague] = useState('');
     const dates = '';
     const prices = '';
+
+    const getLeague = async () => {
+        const response = await fetch(`${process.env.REACT_APP_LAPI_URL}/find/${league}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        const data = await response.json();
+        return data;
+    };
+
+    useEffect(async () => {
+        if (league) {
+            setLeague(await getLeague());
+        }
+    }, [league]);
+
     return (
     // <Container className="custom-cont">
         <div className="centra-league-page">

--- a/frontend/src/components/CentralizedLeague/CentralizedLeague.js
+++ b/frontend/src/components/CentralizedLeague/CentralizedLeague.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 // import Form from 'react-bootstrap/Form';
 // import Container from 'react-bootstrap/Container';
 import '../../styles/CentralizedLeague/CentralizedLeague.scss';
@@ -12,14 +12,18 @@ import { Line } from 'react-chartjs-2';
 
 function CentralizedLeague() {
     const location = useLocation();
-    console.log(location);
 
     const [league, setLeague] = useState('');
-    const dates = '';
-    const prices = '';
-
-    const getLeague = async () => {
-        const response = await fetch(`${process.env.REACT_APP_LAPI_URL}/find/${league}`, {
+    const [leagueData, setLeagueData] = useState(null);
+    const dates = [];
+    const today = new Date();
+    for (let i = 1; i <= 30; i += 1) {
+        const currDate = new Date(new Date().setDate(today.getDate() - i)).toDateString();
+        dates.push(currDate);
+    }
+    /* eslint-disable max-len, arrow-body-style */
+    const getLeagueData = async () => {
+        const response = await fetch(`${process.env.REACT_APP_LAPI_URL}/league/overview/${league}`, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',
@@ -31,14 +35,18 @@ function CentralizedLeague() {
 
     useEffect(async () => {
         if (league) {
-            setLeague(await getLeague());
+            setLeagueData(await getLeagueData());
         }
     }, [league]);
+
+    useEffect(() => {
+        setLeague(location.state.league);
+    }, []);
 
     return (
     // <Container className="custom-cont">
         <div className="centra-league-page">
-            <h1 className="league-header">League Name</h1>
+            <h1 className="league-header">{league}</h1>
             <Row className="lead-graph">
                 <Col sm={6}>
                     <h3>Leaderboard</h3>
@@ -51,77 +59,111 @@ function CentralizedLeague() {
                                 <th>Growth</th>
                             </tr>
                         </thead>
+                        {leagueData && leagueData.portfolios && (
+                            <tbody>
+                                {leagueData.portfolios.map((portfolio) => (
+                                    <tr key={portfolio.owner}>
+                                        <td>{portfolio.position}</td>
+                                        <Link to={{
+                                            pathname: '/portfolio',
+                                            selectedUser: {
+                                                league,
+                                                username: portfolio.owner,
+                                            },
+                                        }}
+                                        >
+                                            <td>{portfolio.owner}</td>
+                                        </Link>
+                                        <td>{portfolio.currentNetWorth}</td>
+                                        <td>{`${portfolio.growth}%`}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        )}
                     </Table>
                 </Col>
                 <Col>
                     <h3 className="graph-header"> League Graph </h3>
                     <div>
-                        <Line
-                            className="Graph"
-                            data={{
-                                labels: dates, // all x values
-                                datasets: [
-                                    {
-                                        label: 'Portfolio Value',
-                                        data: prices, // all y values
-                                        borderColor: 'rgba(98, 252, 3, 1)',
-                                        hoverBackgroundColor: 'blue',
-                                        fill: false,
-                                        borderWidth: 1,
-                                        lineTension: 0.1,
-                                        title: 'League Graph',
+                        {leagueData && leagueData.portfolios && (
+                            <Line
+                                className="Graph"
+                                data={{
+                                    labels: dates, // all x values
+                                    datasets: leagueData.portfolios.map((portfolio) => {
+                                        return {
+                                            label: portfolio.owner,
+                                            data: portfolio.netWorth,
+                                            borderColor: 'rgba(98, 252, 3, 1)',
+                                            hoverBackgroundColor: 'blue',
+                                            fill: false,
+                                            borderWidth: 1,
+                                            lineTension: 0.1,
+                                        };
+                                    }),
+                                    // datasets: [
+                                    //     {
+                                    //         label: 'Portfolio Value',
+                                    //         data: prices, // all y values
+                                    //         borderColor: 'rgba(98, 252, 3, 1)',
+                                    //         hoverBackgroundColor: 'blue',
+                                    //         fill: false,
+                                    //         borderWidth: 1,
+                                    //         lineTension: 0.1,
+                                    //         title: 'League Graph',
+                                    //     },
+                                    // ],
+                                }}
+                                height={400}
+                                width={500}
+                                options={{
+                                    maintainAspectRatio: false,
+                                    tooltips: {
+                                        backgroundColor: 'blue',
                                     },
-                                ],
-                            }}
-                            height={400}
-                            width={500}
-                            options={{
-                                maintainAspectRatio: false,
-                                tooltips: {
-                                    backgroundColor: 'blue',
-                                },
-                                scales: {
-                                    yAxes: [{
-                                        gridLines: {
-                                            color: 'gray',
-                                            zeroLineColor: 'white',
-                                        },
-                                        scaleLabel: {
-                                            display: true,
-                                            fontSize: 15,
-                                            fontColor: 'white',
-                                            fontStyle: 'bold',
-                                            labelString: 'Value',
-                                        },
-                                        ticks: {
-                                            fontColor: 'white',
-                                        },
-                                    }],
-                                    xAxes: [{
-                                        gridLines: {
-                                            color: 'gray',
-                                            zeroLineColor: 'white',
-                                        },
-                                        scaleLabel: {
-                                            display: true,
-                                            fontSize: 15,
-                                            fontColor: 'white',
-                                            fontStyle: 'bold',
-                                            labelString: 'Date',
-                                        },
-                                        ticks: {
-                                            fontColor: 'white',
-                                        },
-                                    }],
-                                },
-                                legend: {
-                                    labels: {
-                                        fontSize: 12,
-                                        fontColor: 'white',
+                                    scales: {
+                                        yAxes: [{
+                                            gridLines: {
+                                                color: 'gray',
+                                                zeroLineColor: 'white',
+                                            },
+                                            scaleLabel: {
+                                                display: true,
+                                                fontSize: 15,
+                                                fontColor: 'white',
+                                                fontStyle: 'bold',
+                                                labelString: 'Value',
+                                            },
+                                            ticks: {
+                                                fontColor: 'white',
+                                            },
+                                        }],
+                                        xAxes: [{
+                                            gridLines: {
+                                                color: 'gray',
+                                                zeroLineColor: 'white',
+                                            },
+                                            scaleLabel: {
+                                                display: true,
+                                                fontSize: 15,
+                                                fontColor: 'white',
+                                                fontStyle: 'bold',
+                                                labelString: 'Date',
+                                            },
+                                            ticks: {
+                                                fontColor: 'white',
+                                            },
+                                        }],
                                     },
-                                },
-                            }}
-                        />
+                                    legend: {
+                                        labels: {
+                                            fontSize: 12,
+                                            fontColor: 'white',
+                                        },
+                                    },
+                                }}
+                            />
+                        )}
                     </div>
                 </Col>
             </Row>
@@ -137,6 +179,18 @@ function CentralizedLeague() {
                             <th>Date</th>
                         </tr>
                     </thead>
+                    {leagueData && leagueData.transactions && (
+                        <tbody>
+                            {leagueData.transactions.map((transaction) => (
+                                <tr>
+                                    <td>{transaction.tickerSymbol}</td>
+                                    <td>{transaction.orderType.slice(-3) === 'Buy' ? 'Buy' : 'Sell'}</td>
+                                    <td>{transaction.quantity}</td>
+                                    <td>{`${new Date(transaction.timePlaced)}`}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    )}
                 </Table>
             </Row>
 

--- a/frontend/src/components/CurrentLeagues/CurrentLeagues.js
+++ b/frontend/src/components/CurrentLeagues/CurrentLeagues.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import ListGroup from 'react-bootstrap/ListGroup';
 import Container from 'react-bootstrap/Container';
 import Alert from 'react-bootstrap/Alert';
@@ -46,7 +47,15 @@ function CurrentLeagues() {
                 <ListGroup className="league-list">
                     {leagues && leagues.map((league) => (
                         <ListGroup.Item>
-                            <p className="current-league-name">{league.leagueName}</p>
+                            <Link to={
+                                {
+                                    pathname: '/centralizedleague',
+                                    state: { league: league.leagueName },
+                                }
+                            }
+                            >
+                                <p className="current-league-name">{league.leagueName}</p>
+                            </Link>
                             {league.portfolioList
                                 && league.portfolioList.map((portfolio) => {
                                     console.log(portfolio);

--- a/frontend/src/components/CurrentLeagues/CurrentLeagues.js
+++ b/frontend/src/components/CurrentLeagues/CurrentLeagues.js
@@ -52,7 +52,7 @@ function CurrentLeagues() {
                                     console.log(portfolio);
                                     if (portfolio.owner === username) {
                                         console.log(portfolio.netWorth);
-                                        return (<p className="current-league-worth">${portfolio.currentNetWorth}({portfolio.currentNetWorth / 500 > 1 ? `+${parseFloat((portfolio.currentNetWorth / 500 - 1) * 100).toFixed(2)}%` : `-${parseFloat((1 - portfolio.currentNetWorth / 500) * 100).toFixed(2)}%` })</p>);
+                                        return (<p className="current-league-worth">${portfolio.currentNetWorth.toFixed(2)}({portfolio.currentNetWorth / 500 > 1 ? `+${parseFloat((portfolio.currentNetWorth / 500 - 1) * 100).toFixed(2)}%` : `-${parseFloat((1 - portfolio.currentNetWorth / 500) * 100).toFixed(2)}%` })</p>);
                                     }
                                     console.log('NOne');
                                     return null;

--- a/frontend/src/components/CurrentLeagues/CurrentLeagues.js
+++ b/frontend/src/components/CurrentLeagues/CurrentLeagues.js
@@ -63,7 +63,6 @@ function CurrentLeagues() {
                                         console.log(portfolio.netWorth);
                                         return (<p className="current-league-worth">${portfolio.currentNetWorth.toFixed(2)}({portfolio.currentNetWorth / 500 > 1 ? `+${parseFloat((portfolio.currentNetWorth / 500 - 1) * 100).toFixed(2)}%` : `-${parseFloat((1 - portfolio.currentNetWorth / 500) * 100).toFixed(2)}%` })</p>);
                                     }
-                                    console.log('NOne');
                                     return null;
                                 })}
                         </ListGroup.Item>

--- a/frontend/src/components/Portfolio/Portfolio.js
+++ b/frontend/src/components/Portfolio/Portfolio.js
@@ -15,11 +15,14 @@ const Portfolio = () => {
     const [leagueList, setLeagueList] = useState();
     const [portfolio, setPortfolio] = useState();
     const [lowBalance, setLowBalance] = useState(false);
+    const [viewUser, setViewUser] = useState(username);
+    const [leagueObj, setLeagueObj] = useState(null);
 
     const handleClose = () => setLowBalance(false);
 
     const getPortfolio = async () => {
-        const response = await fetch(`${process.env.REACT_APP_LAPI_URL}/league/portfolio/${league}`, {
+        console.log(viewUser);
+        const response = await fetch(`${process.env.REACT_APP_LAPI_URL}/league/specifiedportfolio/${league}/${viewUser}`, {
             method: 'GET',
             headers: {
                 Authorization: `Bearer ${localStorage.getItem('token')}`,
@@ -28,7 +31,7 @@ const Portfolio = () => {
         });
         const data = await response.json();
         setPortfolio(data);
-        if (data.currentNetWorth < 600) {
+        if (data.currentNetWorth < 600 && viewUser === username) {
             setLowBalance(true);
         }
     };
@@ -46,9 +49,27 @@ const Portfolio = () => {
         return data;
     };
 
+    // Required to get playerlist and other users portfolios
+    const getLeague = async () => {
+        const response = await fetch(`${process.env.REACT_APP_LAPI_URL}/league/find/${league}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        const data = await response.json()
+            .then((result) => setLeagueObj(result));
+        return data;
+    };
+
+    useEffect(() => {
+        getPortfolio();
+    }, [viewUser]);
+
     useEffect(() => {
         getLeagues();
         getPortfolio();
+        getLeague();
     }, [league]);
 
     return (
@@ -72,6 +93,18 @@ const Portfolio = () => {
                                 {leagueList && leagueList.map((userLeague) => (
                                     <Dropdown.Item onClick={(() => setLeague(userLeague.leagueName))}>
                                         {userLeague.leagueName}
+                                    </Dropdown.Item>
+                                ))}
+                            </DropdownButton>
+                        </div>
+                    )}
+                {leagueObj
+                    && (
+                        <div>
+                            <DropdownButton title={viewUser || 'Choose Player'} className="portfolio-dropdown" size="lg">
+                                {leagueObj && leagueObj.playerList.map((user) => (
+                                    <Dropdown.Item onClick={(() => setViewUser(user))}>
+                                        {user}
                                     </Dropdown.Item>
                                 ))}
                             </DropdownButton>

--- a/frontend/src/components/Portfolio/Portfolio.js
+++ b/frontend/src/components/Portfolio/Portfolio.js
@@ -24,7 +24,6 @@ const Portfolio = () => {
     const handleClose = () => setLowBalance(false);
 
     const getPortfolio = async () => {
-        console.log(viewUser);
         const response = await fetch(`${process.env.REACT_APP_LAPI_URL}/league/specifiedportfolio/${league}/${viewUser}`, {
             method: 'GET',
             headers: {
@@ -67,8 +66,6 @@ const Portfolio = () => {
 
     // Set league and username if sent in state
     useEffect(() => {
-        console.log('loaded');
-        console.log(location);
         if (location.state && 'selectedUser' in location.state) {
             setLeague(location.state.selectedUser.league);
             setViewUser(location.state.selectedUser.username);

--- a/frontend/src/components/Portfolio/Portfolio.js
+++ b/frontend/src/components/Portfolio/Portfolio.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Dropdown } from 'react-bootstrap';
 import DropdownButton from 'react-bootstrap/DropdownButton';
 import Modal from 'react-bootstrap/Modal';
@@ -10,6 +11,8 @@ import '../../styles/Portfolio/Portfolio.scss';
 const Portfolio = () => {
     /* eslint-disable max-len */
     const username = sessionStorage.getItem('username');
+
+    const location = useLocation();
 
     const [league, setLeague] = useState(null);
     const [leagueList, setLeagueList] = useState();
@@ -61,6 +64,16 @@ const Portfolio = () => {
             .then((result) => setLeagueObj(result));
         return data;
     };
+
+    // Set league and username if sent in state
+    useEffect(() => {
+        console.log('loaded');
+        console.log(location);
+        if (location.state && 'selectedUser' in location.state) {
+            setLeague(location.state.selectedUser.league);
+            setViewUser(location.state.selectedUser.username);
+        }
+    }, []);
 
     useEffect(() => {
         getPortfolio();

--- a/frontend/src/components/Portfolio/Portfolio.js
+++ b/frontend/src/components/Portfolio/Portfolio.js
@@ -12,14 +12,14 @@ const Portfolio = () => {
     /* eslint-disable max-len */
     const username = sessionStorage.getItem('username');
 
-    const location = useLocation();
-
-    const [league, setLeague] = useState(null);
+    const [league, setLeague] = useState('');
     const [leagueList, setLeagueList] = useState();
     const [portfolio, setPortfolio] = useState();
     const [lowBalance, setLowBalance] = useState(false);
     const [viewUser, setViewUser] = useState(username);
     const [leagueObj, setLeagueObj] = useState(null);
+
+    const location = useLocation();
 
     const handleClose = () => setLowBalance(false);
 
@@ -66,11 +66,11 @@ const Portfolio = () => {
 
     // Set league and username if sent in state
     useEffect(() => {
-        if (location.state && 'selectedUser' in location.state) {
-            setLeague(location.state.selectedUser.league);
-            setViewUser(location.state.selectedUser.username);
+        if (location && location.selectedUser) {
+            setLeague(location.selectedUser.league);
+            setViewUser(location.selectedUser.username);
         }
-    }, []);
+    }, [location]);
 
     useEffect(() => {
         getPortfolio();

--- a/frontend/src/components/Portfolio/Sections/Positions.js
+++ b/frontend/src/components/Portfolio/Sections/Positions.js
@@ -5,7 +5,6 @@ import '../../../styles/Portfolio/Positions.scss';
 
 const Positions = (props) => {
     const { portfolio } = props;
-    console.log(portfolio);
     /* eslint-disable max-len */
 
     return (


### PR DESCRIPTION
Mostly resolves #128
Resolves #113

Added links in current leagues page:
![image](https://user-images.githubusercontent.com/31025257/115644748-1482d700-a2ed-11eb-84c2-64260ead8b6d.png)

Redirects to centralized league page:
![image](https://user-images.githubusercontent.com/31025257/115646937-0636ba00-a2f1-11eb-8b44-f07c4db82420.png)

- Created `/league/overview/:leagueName` endpoint for providing data
- Accepts `state.league` prop to determine league to display

Clicking on a user redirects to portfolio page for that league and user:
![image](https://user-images.githubusercontent.com/31025257/115647007-20709800-a2f1-11eb-8712-c5d2a8b1eb03.png)

- Accepts `selectedUser.league` and `selectedUser.username` props for determining which portfolio to display

Known issues:

- Link in table causes weird formatting for list of users
- Graph has not really been implemented because I don't have data; will create issue for this
- General styling