### PR TITLE
Added relevant metrics to portfolio page and fixed styling

### DIFF
--- a/frontend/src/components/Portfolio/Sections/PortfolioGraph.js
+++ b/frontend/src/components/Portfolio/Sections/PortfolioGraph.js
@@ -4,6 +4,7 @@ import { Line } from 'react-chartjs-2';
 import '../../../styles/Portfolio/PortfolioGraph.scss';
 
 const PortfolioGraph = (props) => {
+    /* eslint-disable max-len */
     const { portfolio } = props;
     let dates = '';
     let prices = '';
@@ -17,15 +18,15 @@ const PortfolioGraph = (props) => {
             {portfolio && portfolio.currentNetWorth
                 && (
                     <div className="portfolio-header">
-                        <h3>
-                            <b>Account Value: </b>
-                            ${portfolio.currentNetWorth}&emsp;&emsp;
-                            <b>Buying Power: </b>
-                            ${portfolio.cashAvailable}&emsp;&emsp;
-                            <b>Total Return: </b>
-                            ${(portfolio.currentNetWorth - 500).toFixed(2)}
-                            ({portfolio.currentNetWorth / 500 > 1 ? `+${parseFloat((portfolio.currentNetWorth / 500 - 1) * 100).toFixed(2)}%` : `-${parseFloat((1 - portfolio.currentNetWorth / 500) * 100).toFixed(2)}` })
-                        </h3>
+                        <h1 className="portfolio-current">${portfolio.currentNetWorth}</h1> &nbsp;
+                        <p className="portfolio-gain"> Today&apos;s Gain: </p> &nbsp;
+                        {portfolio.closePercentChange > 0
+                            ? <p className="portfolio-gain" style={{ color: portfolio.closePercentChange > 0 ? 'green' : 'red' }}>${(portfolio.currentNetWorth * (portfolio.closePercentChange / 100)).toFixed(2)}&nbsp;(+{portfolio.closePercentChange}%)</p>
+                            : <p className="portfolio-gain" style={{ color: portfolio.closePercentChange > 0 ? 'green' : 'red' }}>${(portfolio.currentNetWorth * (portfolio.closePercentChange / 100)).toFixed(2)}&nbsp;({portfolio.closePercentChange}%)</p> }
+                        &nbsp; <p className="portfolio-gain">Total Gain: </p> &nbsp;
+                        {portfolio.currentNetWorth - 500 > 0
+                            ? <p className="portfolio-gain" style={{ color: portfolio.currentNetWorth - 500 > 0 ? 'green' : 'red' }}>${(portfolio.currentNetWorth - 500).toFixed(2)}&nbsp;(+{portfolio.currentNetWorth / 500 > 1 ? `+${parseFloat((portfolio.currentNetWorth / 500 - 1) * 100).toFixed(2)}%` : `-${parseFloat((1 - portfolio.currentNetWorth / 500) * 100).toFixed(2)}%` })</p>
+                            : <p className="portfolio-gain" style={{ color: portfolio.currentNetWorth - 500 > 0 ? 'green' : 'red' }}>${(portfolio.currentNetWorth - 500).toFixed(2)}&nbsp;({portfolio.currentNetWorth / 500 > 1 ? `+${parseFloat((portfolio.currentNetWorth / 500 - 1) * 100).toFixed(2)}%` : `-${parseFloat((1 - portfolio.currentNetWorth / 500) * 100).toFixed(2)}%` })</p> }
                     </div>
                 )}
             {portfolio && portfolio.netWorth

--- a/frontend/src/components/Portfolio/Sections/PortfolioHistory.js
+++ b/frontend/src/components/Portfolio/Sections/PortfolioHistory.js
@@ -20,8 +20,8 @@ const PortfolioHistory = (props) => {
                                     <th>Date Placed</th>
                                     <th>Ticker</th>
                                     <th>Quantity</th>
-                                    <th>Price Per Share</th>
-                                    <th>Total Price</th>
+                                    <th>Price Per Share($)</th>
+                                    <th>Total Price($)</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -29,7 +29,7 @@ const PortfolioHistory = (props) => {
                                     /* eslint-disable no-underscore-dangle, max-len */
                                     <tr key={order._id}>
                                         <td>{new Date(order.timePlaced).toString().split('GMT')[0]}</td>
-                                        <td>{order.tickerSymbol}</td>
+                                        <td>{(order.tickerSymbol).toUpperCase()}</td>
                                         <td>{order.quantity}</td>
                                         <td>{parseFloat(order.pricePerShare).toFixed(2)}</td>
                                         <td>{parseFloat(order.totalPrice).toFixed(2)}</td>

--- a/frontend/src/components/Portfolio/Sections/Positions.js
+++ b/frontend/src/components/Portfolio/Sections/Positions.js
@@ -21,10 +21,11 @@ const Positions = (props) => {
                                 <th>Symbol</th>
                                 <th>Description</th>
                                 <th>Quantity</th>
-                                <th>Current Price</th>
-                                <th>Total Value</th>
-                                <th>Average Cost Basis</th>
-                                <th>Total Change</th>
+                                <th>Current Price($)</th>
+                                <th>Total Value($)</th>
+                                <th>Average Cost Basis($)</th>
+                                <th>Total Gain($)</th>
+                                <th>Day Gain(%)</th>
                             </tr>
                         </thead>
                         {portfolio
@@ -33,13 +34,14 @@ const Positions = (props) => {
                                     {portfolio.holdings
                                     && Object.keys(portfolio.holdings).map((ticker) => (
                                         <tr key={ticker}>
-                                            <td>{ticker}</td>
+                                            <td>{ticker.toUpperCase()}</td>
                                             <td>{portfolio.holdings[ticker].equityName}</td>
                                             <td>{portfolio.holdings[ticker].quantity}</td>
                                             <td>{portfolio.holdings[ticker].currentPrice}</td>
                                             <td>{portfolio.holdings[ticker].totalValue}</td>
                                             <td>{portfolio.holdings[ticker].costBasis}</td>
                                             <td>{portfolio.holdings[ticker].totalChange}</td>
+                                            <td>{portfolio.holdings[ticker].closePercentChange}</td>
                                         </tr>
                                     ))}
                                 </tbody>

--- a/frontend/src/styles/CentralizedLeague/CentralizedLeague.scss
+++ b/frontend/src/styles/CentralizedLeague/CentralizedLeague.scss
@@ -4,10 +4,6 @@
     background-color: var(--light-scale-grey);
 }
 
-h3{
-    color: #3fc380;
-}
-
 .league-header{
     color: #5367fc;
     text-align: center;
@@ -17,6 +13,10 @@ h3{
 .centra-league-page{
     margin-left:10vw;
     margin-top:5vh;
+
+    h3{
+        color: #3fc380;
+    }
    
 }
 

--- a/frontend/src/styles/Portfolio/PortfolioGraph.scss
+++ b/frontend/src/styles/Portfolio/PortfolioGraph.scss
@@ -12,7 +12,17 @@
 
 .portfolio-header{
     display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    flex-direction: row;
+    align-items: flex-end;
+
+    .portfolio-current {
+        font-weight: bold;
+    }
+
+    .portfolio-gain{
+        font-size: 25px;
+    }
 }
+
+
+

--- a/frontend/src/styles/root.scss
+++ b/frontend/src/styles/root.scss
@@ -37,7 +37,6 @@
   }
 
   .container {
-    height: 80vh;
     display: flex;
     justify-content: flex-start;
   }


### PR DESCRIPTION
Added day gain for each portfolio holding and also day gain and total gain metrics for portfolio value. Also fixed the styling, namely the gap between the transaction history and the positions table.

Screenshot.
![image](https://user-images.githubusercontent.com/29742300/115658548-f924c580-a306-11eb-9794-6fcaef67e2a6.png)
